### PR TITLE
C-2175: Toast UI redesign

### DIFF
--- a/dist/components/Body/index.js
+++ b/dist/components/Body/index.js
@@ -29,8 +29,41 @@ var Body = (_ref) => {
   var {
     title,
     body,
-    icon
+    icon,
+    data
   } = _ref;
+  var sideBar;
+  var {
+    clientKey
+  } = (0, _react.useContext)(_providers.ToastContext);
+
+  if (data !== null && data !== void 0 && data.clickAction) {
+    var handleClickAction = () => {
+      if (clientKey && data !== null && data !== void 0 && data.clickedUrl) {
+        fetch("".concat(data.clickedUrl), {
+          method: "POST",
+          headers: {
+            "x-courier-client-key": clientKey
+          }
+        });
+      }
+    };
+
+    sideBar = /*#__PURE__*/_react.default.createElement(_styled.SideBarContainer, null, /*#__PURE__*/_react.default.createElement(_styled.Details, {
+      onClick: handleClickAction
+    }, "Details"), /*#__PURE__*/_react.default.createElement(_styled.Dismiss, {
+      onClick: () => {
+        _reactToastify.toast.dismiss();
+      }
+    }, "Dismiss"));
+  } else {
+    sideBar = /*#__PURE__*/_react.default.createElement(_styled.SideBarContainer, null, /*#__PURE__*/_react.default.createElement(_styled.Dismiss, {
+      onClick: () => {
+        _reactToastify.toast.dismiss();
+      }
+    }, "Dismiss"));
+  }
+
   return /*#__PURE__*/_react.default.createElement(_react.default.Fragment, null, /*#__PURE__*/_react.default.createElement("div", {
     className: "courier__icon"
   }, icon ? /*#__PURE__*/_react.default.createElement("img", {
@@ -45,40 +78,10 @@ var Body = (_ref) => {
 };
 
 var BodyWrapper = (_ref2) => {
-  var _props$data;
-
   var {
     onClick
   } = _ref2,
       props = _objectWithoutProperties(_ref2, ["onClick"]);
-
-  var {
-    clientKey
-  } = (0, _react.useContext)(_providers.ToastContext);
-  var courierData = (_props$data = props === null || props === void 0 ? void 0 : props.data) !== null && _props$data !== void 0 ? _props$data : {};
-
-  if (courierData !== null && courierData !== void 0 && courierData.clickAction || onClick) {
-    var handleOnClick = event => {
-      if (onClick) {
-        onClick(event);
-      }
-
-      if (clientKey && courierData.clickedUrl) {
-        fetch("".concat(courierData.clickedUrl), {
-          method: "POST",
-          headers: {
-            "x-courier-client-key": clientKey
-          }
-        });
-      }
-    };
-
-    return /*#__PURE__*/_react.default.createElement(_styled.AnchorContainer, {
-      target: "__blank",
-      href: courierData === null || courierData === void 0 ? void 0 : courierData.clickAction,
-      onClick: handleOnClick
-    }, /*#__PURE__*/_react.default.createElement(Body, props));
-  }
 
   return /*#__PURE__*/_react.default.createElement(_styled.Container, null, /*#__PURE__*/_react.default.createElement(Body, props));
 };

--- a/dist/components/Body/index.js
+++ b/dist/components/Body/index.js
@@ -9,6 +9,8 @@ var _react = _interopRequireWildcard(require("react"));
 
 var _providers = require("../../providers");
 
+var _reactToastify = require("react-toastify");
+
 var _styled = require("./styled");
 
 var _courierIcon = _interopRequireDefault(require("./courier-icon"));
@@ -39,7 +41,7 @@ var Body = (_ref) => {
     className: "courier__title"
   }, title), /*#__PURE__*/_react.default.createElement("div", {
     className: "courier__body"
-  }, body)));
+  }, body)), sideBar);
 };
 
 var BodyWrapper = (_ref2) => {

--- a/dist/components/Body/styled.js
+++ b/dist/components/Body/styled.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.ContentContainer = exports.AnchorContainer = exports.Container = void 0;
+exports.Dismiss = exports.Details = exports.SideBarContainer = exports.ContentContainer = exports.Container = void 0;
 
 var _styledComponents = _interopRequireDefault(require("styled-components"));
 
@@ -38,7 +38,7 @@ var AnchorContainer = _styledComponents.default.a.withConfig({
 })); //@ts-ignore
 
 
-exports.AnchorContainer = AnchorContainer;
+exports.ContentContainer = ContentContainer;
 
 var ContentContainer = _styledComponents.default.pre.withConfig({
   displayName: "styled__ContentContainer",
@@ -52,4 +52,4 @@ var ContentContainer = _styledComponents.default.pre.withConfig({
   margin: "10px 0"
 }));
 
-exports.ContentContainer = ContentContainer;
+exports.Dismiss = Dismiss;

--- a/dist/components/Body/styled.js
+++ b/dist/components/Body/styled.js
@@ -46,7 +46,9 @@ var SideBarContainer = _styledComponents.default.div.withConfig({
   alignSelf: "center",
   display: "flex",
   flexDirection: "column",
-  marginLeft: 5
+  marginLeft: 5,
+  paddingLeft: 5,
+  borderLeft: "1px solid #CBD5E0"
 }));
 
 exports.SideBarContainer = SideBarContainer;
@@ -57,12 +59,13 @@ var Details = _styledComponents.default.a.withConfig({
 })(() => ({
   backgroundColor: "white",
   border: "none",
+  borderBottom: "1px solid #CBD5E0",
   color: "#9D3789",
   fontFamily: "\"Nunito Sans\", sans-serif",
   fontSize: 12,
   textAlign: "center",
   margin: 5,
-  paddingBottom: 5
+  paddingBottom: 10
 }));
 
 exports.Details = Details;

--- a/dist/components/Body/styled.js
+++ b/dist/components/Body/styled.js
@@ -20,36 +20,64 @@ var Container = _styledComponents.default.div.withConfig({
   border: "none",
   color: "inherit",
   backgroundColor: "inherit"
-}));
-
-exports.Container = Container;
-
-var AnchorContainer = _styledComponents.default.a.withConfig({
-  displayName: "styled__AnchorContainer",
-  componentId: "swto7w-1"
-})(() => ({
-  height: "100%",
-  width: "100%",
-  display: "flex",
-  outline: "none",
-  border: "none",
-  color: "inherit",
-  backgroundColor: "inherit"
 })); //@ts-ignore
 
 
-exports.ContentContainer = ContentContainer;
+exports.Container = Container;
 
 var ContentContainer = _styledComponents.default.pre.withConfig({
   displayName: "styled__ContentContainer",
-  componentId: "swto7w-2"
+  componentId: "swto7w-1"
 })(() => ({
   display: "flex",
   width: "100%",
   alignItems: "flex-start",
   flexDirection: "column",
   whiteSpace: "break-spaces",
-  margin: "10px 0"
+  margin: 10
+}));
+
+exports.ContentContainer = ContentContainer;
+
+var SideBarContainer = _styledComponents.default.div.withConfig({
+  displayName: "styled__SideBarContainer",
+  componentId: "swto7w-2"
+})(() => ({
+  alignSelf: "center",
+  display: "flex",
+  flexDirection: "column",
+  marginLeft: 5
+}));
+
+exports.SideBarContainer = SideBarContainer;
+
+var Details = _styledComponents.default.a.withConfig({
+  displayName: "styled__Details",
+  componentId: "swto7w-3"
+})(() => ({
+  backgroundColor: "white",
+  border: "none",
+  color: "#9D3789",
+  fontFamily: "\"Nunito Sans\", sans-serif",
+  fontSize: 12,
+  textAlign: "center",
+  margin: 5,
+  paddingBottom: 5
+}));
+
+exports.Details = Details;
+
+var Dismiss = _styledComponents.default.a.withConfig({
+  displayName: "styled__Dismiss",
+  componentId: "swto7w-4"
+})(() => ({
+  backgroundColor: "white",
+  border: "none",
+  color: "#73819B",
+  fontFamily: "\"Nunito Sans\", sans-serif",
+  fontSize: 12,
+  textAlign: "center",
+  margin: 5
 }));
 
 exports.Dismiss = Dismiss;

--- a/dist/components/Toast/index.js
+++ b/dist/components/Toast/index.js
@@ -27,7 +27,9 @@ var Toast = () => {
   return /*#__PURE__*/_react.default.createElement(_styled.ToastStyled, _extends({
     "data-test-id": "crt-toast-container"
   }, config, {
-    transition: Transition
+    transition: Transition,
+    closeButton: false,
+    closeOnClick: false
   }));
 };
 

--- a/dist/providers/defaults.js
+++ b/dist/providers/defaults.js
@@ -8,8 +8,8 @@ var defaultConfig = {
   hideProgressBar: false,
   position: "top-right",
   theme: {
-    "container": {
-      "a": {
+    container: {
+      a: {
         textDecoration: "none",
         backgroundColor: "white"
       },
@@ -17,7 +17,7 @@ var defaultConfig = {
         fontFamily: "\"Nunito Sans\", sans-serif"
       }
     },
-    "toast": {
+    toast: {
       minHeight: 50,
       backgroundColor: "white",
       boxShadow: "rgba(157, 55, 137, 0.2) 0px 4px 12px",
@@ -25,24 +25,26 @@ var defaultConfig = {
       color: "black",
       margin: 10
     },
-    "title": {
+    title: {
       fontSize: 14,
       fontWeight: "bold",
       color: "#344563"
     },
-    "body": {
+    body: {
       fontSize: 12,
       color: "#8F8F8F",
       marginTop: 4
     },
-    "icon": {
+    icon: {
       height: 30,
       width: 30,
-      marginRight: 12
+      marginRight: 16,
+      alignSelf: "center"
     },
-    "progressBar": {
+    progressBar: {
       background: "rgb(157, 55, 137)",
-      height: 3
+      height: 3,
+      top: 0
     }
   },
   transition: "slide"

--- a/src/components/Body/index.tsx
+++ b/src/components/Body/index.tsx
@@ -1,40 +1,29 @@
 import React, { useContext } from "react";
 import { ToastContext } from "../../providers";
 import { IToastMessage } from "../Toast/types";
-import { AnchorContainer, Container, ContentContainer } from "./styled";
+import { toast } from "react-toastify";
+import {
+  Container,
+  ContentContainer,
+  SideBarContainer,
+  Details,
+  Dismiss,
+} from "./styled";
 import CourierIcon from "./courier-icon";
 
 const Body: React.FunctionComponent<Partial<IToastMessage>> = ({
   title,
   body,
   icon,
-}) => (
-  <>
-    <div className="courier__icon">
-      {icon ? <img src={icon} /> : <CourierIcon />}
-    </div>
-    <ContentContainer className="courier__container">
-      <div className="courier__title">{title}</div>
-      <div className="courier__body">{body}</div>
-    </ContentContainer>
-  </>
-);
-
-const BodyWrapper: React.FunctionComponent<IToastMessage> = ({
-  onClick,
-  ...props
+  data,
 }) => {
+  let sideBar;
   const { clientKey } = useContext(ToastContext);
-  const courierData = props?.data ?? {};
 
-  if (courierData?.clickAction || onClick) {
-    const handleOnClick = (event: React.MouseEvent) => {
-      if (onClick) {
-        onClick(event);
-      }
-
-      if (clientKey && courierData.clickedUrl) {
-        fetch(`${courierData.clickedUrl}`, {
+  if (data?.clickAction) {
+    const handleClickAction = () => {
+      if (clientKey && data?.clickedUrl) {
+        fetch(`${data.clickedUrl}`, {
           method: "POST",
           headers: {
             "x-courier-client-key": clientKey,
@@ -43,17 +32,50 @@ const BodyWrapper: React.FunctionComponent<IToastMessage> = ({
       }
     };
 
-    return (
-      <AnchorContainer
-        target="__blank"
-        href={courierData?.clickAction}
-        onClick={handleOnClick}
-      >
-        <Body {...props} />
-      </AnchorContainer>
+    sideBar = (
+      <SideBarContainer>
+        <Details onClick={handleClickAction}>Details</Details>
+        <Dismiss
+          onClick={() => {
+            toast.dismiss();
+          }}
+        >
+          Dismiss
+        </Dismiss>
+      </SideBarContainer>
+    );
+  } else {
+    sideBar = (
+      <SideBarContainer>
+        <Dismiss
+          onClick={() => {
+            toast.dismiss();
+          }}
+        >
+          Dismiss
+        </Dismiss>
+      </SideBarContainer>
     );
   }
 
+  return (
+    <>
+      <div className="courier__icon">
+        {icon ? <img src={icon} /> : <CourierIcon />}
+      </div>
+      <ContentContainer className="courier__container">
+        <div className="courier__title">{title}</div>
+        <div className="courier__body">{body}</div>
+      </ContentContainer>
+      {sideBar}
+    </>
+  );
+};
+
+const BodyWrapper: React.FunctionComponent<IToastMessage> = ({
+  onClick,
+  ...props
+}) => {
   return (
     <Container>
       <Body {...props} />

--- a/src/components/Body/styled.ts
+++ b/src/components/Body/styled.ts
@@ -10,16 +10,6 @@ export const Container = styled.div(() => ({
   backgroundColor: "inherit",
 }));
 
-export const AnchorContainer = styled.a(() => ({
-  height: "100%",
-  width: "100%",
-  display: "flex",
-  outline: "none",
-  border: "none",
-  color: "inherit",
-  backgroundColor: "inherit",
-}));
-
 //@ts-ignore
 export const ContentContainer = styled.pre(() => ({
   display: "flex",
@@ -27,5 +17,33 @@ export const ContentContainer = styled.pre(() => ({
   alignItems: "flex-start",
   flexDirection: "column",
   whiteSpace: "break-spaces",
-  margin: "10px 0",
+  margin: 10,
+}));
+
+export const SideBarContainer = styled.div(() => ({
+  alignSelf: "center",
+  display: "flex",
+  flexDirection: "column",
+  marginLeft: 5,
+}));
+
+export const Details = styled.a(() => ({
+  backgroundColor: "white",
+  border: "none",
+  color: "#9D3789",
+  fontFamily: `"Nunito Sans", sans-serif`,
+  fontSize: 12,
+  textAlign: "center",
+  margin: 5,
+  paddingBottom: 5,
+}));
+
+export const Dismiss = styled.a(() => ({
+  backgroundColor: "white",
+  border: "none",
+  color: "#73819B",
+  fontFamily: `"Nunito Sans", sans-serif`,
+  fontSize: 12,
+  textAlign: "center",
+  margin: 5,
 }));

--- a/src/components/Body/styled.ts
+++ b/src/components/Body/styled.ts
@@ -25,17 +25,20 @@ export const SideBarContainer = styled.div(() => ({
   display: "flex",
   flexDirection: "column",
   marginLeft: 5,
+  paddingLeft: 5,
+  borderLeft: "1px solid #CBD5E0",
 }));
 
 export const Details = styled.a(() => ({
   backgroundColor: "white",
   border: "none",
+  borderBottom: "1px solid #CBD5E0",
   color: "#9D3789",
   fontFamily: `"Nunito Sans", sans-serif`,
   fontSize: 12,
   textAlign: "center",
   margin: 5,
-  paddingBottom: 5,
+  paddingBottom: 10,
 }));
 
 export const Dismiss = styled.a(() => ({

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -7,7 +7,15 @@ const Toast: React.FunctionComponent = () => {
   const { config } = useContext(ToastContext);
 
   const Transition = getTransition(config.transition);
-  return <ToastStyled data-test-id="crt-toast-container" {...config} transition={Transition} />;
+  return (
+    <ToastStyled
+      data-test-id="crt-toast-container"
+      {...config}
+      transition={Transition}
+      closeButton={false}
+      closeOnClick={false}
+    />
+  );
 };
 
 export default Toast;

--- a/src/providers/defaults.ts
+++ b/src/providers/defaults.ts
@@ -4,16 +4,16 @@ export const defaultConfig: IProviderConfig = {
   hideProgressBar: false,
   position: "top-right",
   theme: {
-    "container": {
-      "a": {
+    container: {
+      a: {
         textDecoration: "none",
         backgroundColor: "white",
       },
-      "*" :{
+      "*": {
         fontFamily: `"Nunito Sans", sans-serif`,
       },
     },
-    "toast": {
+    toast: {
       minHeight: 50,
       backgroundColor: "white",
       boxShadow: "rgba(157, 55, 137, 0.2) 0px 4px 12px",
@@ -21,24 +21,26 @@ export const defaultConfig: IProviderConfig = {
       color: "black",
       margin: 10,
     },
-    "title":{
+    title: {
       fontSize: 14,
       fontWeight: "bold",
       color: "#344563",
     },
-    "body": {
+    body: {
       fontSize: 12,
       color: "#8F8F8F",
       marginTop: 4,
     },
-    "icon": {
+    icon: {
       height: 30,
       width: 30,
-      marginRight: 12,
+      marginRight: 16,
+      alignSelf: "center",
     },
-    "progressBar": {
+    progressBar: {
       background: "rgb(157, 55, 137)",
       height: 3,
+      top: 0,
     },
   },
   transition: "slide",

--- a/stories/Toast.stories.js
+++ b/stories/Toast.stories.js
@@ -9,12 +9,12 @@ export default {
   title: "Example/Toast",
   component: Toast,
   args: {
-    bodyText: "Click here to view more details",
+    bodyText: "One API for notifications!",
   },
 };
 export function Default({ bodyText }) {
   return (
-    <ToastProvider>
+    <ToastProvider clientKey="client-key">
       <DefaultComponent body={bodyText} />
     </ToastProvider>
   );
@@ -23,9 +23,12 @@ export function Default({ bodyText }) {
 function DefaultComponent({ body }) {
   const [ toast ] = useToast();
   const notification = {
-    title: "Your notification has been sent!",
+    title: "Courier",
     body,
-    clickAction: "https://app.courier.com",
+    data: {
+      clickAction: "https://app.courier.com",
+      clickedUrl: "https://api.courier.com/something/send",
+    },
     options:{
       hideProgressBar: false,
     },


### PR DESCRIPTION
## Description

a. Moved progress Bar to the top
b. Make body not clickable
c. Align icon appropriately (it was sticking to the topleft before)
d. Dismiss button if no clickAction is provided and clicking on it programmatically dismisses the toast
e. if clickAction is provided, show Details button, and if clickedUrl and clientKey is available, call the url with `fetch()`

<img width="330" alt="Screen Shot 2021-02-18 at 11 27 42 PM" src="https://user-images.githubusercontent.com/6154318/108472627-da8c4a80-7241-11eb-9d60-f04eef9b184b.png">

<img width="326" alt="Screen Shot 2021-02-18 at 11 27 20 PM" src="https://user-images.githubusercontent.com/6154318/108472645-deb86800-7241-11eb-8468-ed5a1d55863b.png">

What I am missing yet: Border between body and side bar, Border between the Details and Dismiss.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
